### PR TITLE
[Request For Comments] CSS Transitions on React (Gacha)

### DIFF
--- a/client/components/Gacha/Gacha.jsx
+++ b/client/components/Gacha/Gacha.jsx
@@ -14,12 +14,14 @@ class Gacha extends Component {
       rarity: "",
       envelope_image_closed: "",
       envelope_image_open: "",
-      open_sound: ""
+      open_sound: "",
+      envelopeIsOpened: false
     };
 
     this.resetGacha = this.resetGacha.bind(this);
     this.getGacha = this.getGacha.bind(this);
     this.enableGachaAnimation = this.enableGachaAnimation.bind(this);
+    this.openEnvelope = this.openEnvelope.bind(this);
   }
 
   // Resets game state to default states; open_sound has to be pre-populated
@@ -33,7 +35,8 @@ class Gacha extends Component {
       rarity: "",
       envelope_image_closed: "loading.gif",
       envelope_image_open: "",
-      open_sound: "r_open.mp3"
+      open_sound: "r_open.mp3",
+      envelopeIsOpened: false
     });
   }
 
@@ -80,12 +83,15 @@ class Gacha extends Component {
   enableGachaAnimation() {
     const $closed_envelope = $(".envelope-closed");
     const $open_envelope = $(".envelope-open");
-    let $data_blob = $(".data");
-    $data_blob.data("open-sound-url", "/statics/sound/" + this.state.open_sound);
-    let audio = new Audio($data_blob.data("open-sound-url"));
+
+    const soundElement = document.getElementsByClassName("data")[0];
+    soundElement.setAttribute("data-open-sound-url", "/statics/sound/" + this.state.open_sound);
+    const soundData = soundElement.getAttribute("data-open-sound-url");
+    const audio = new Audio(soundData);
 
     const animateOpeningBox = () => {
       // Replace the closed envelope with the open one
+      $closed_envelope.removeClass("reveal");
       $closed_envelope.addClass("hide");
       $open_envelope.removeClass("hide");
 
@@ -108,6 +114,15 @@ class Gacha extends Component {
     });
   }
 
+  // Triggers envelopeIsOpened state upon clicking a closed envelope
+
+  openEnvelope() {
+    console.log('Opening envelope...');
+    this.setState({
+      envelopeIsOpened: true,
+    });
+  }
+
   // Retrieves data before presentation of the virtual DOM
 
   componentWillMount() {
@@ -123,7 +138,7 @@ class Gacha extends Component {
   render() {
     return (
       <div>
-        <GachaContent gameState={this.state} getGacha={this.getGacha} />
+        <GachaContent gameState={this.state} getGacha={this.getGacha} openEnvelope={this.openEnvelope} />
       </div>
     );
   }

--- a/client/components/Gacha/Gacha.jsx
+++ b/client/components/Gacha/Gacha.jsx
@@ -22,6 +22,7 @@ class Gacha extends Component {
     this.getGacha = this.getGacha.bind(this);
     this.enableGachaAnimation = this.enableGachaAnimation.bind(this);
     this.openEnvelope = this.openEnvelope.bind(this);
+    this.enableSound = this.enableSound.bind(this);
   }
 
   // Resets game state to default states; open_sound has to be pre-populated
@@ -84,11 +85,6 @@ class Gacha extends Component {
     const $closed_envelope = $(".envelope-closed");
     const $open_envelope = $(".envelope-open");
 
-    const soundElement = document.getElementsByClassName("data")[0];
-    soundElement.setAttribute("data-open-sound-url", "/statics/sound/" + this.state.open_sound);
-    const soundData = soundElement.getAttribute("data-open-sound-url");
-    const audio = new Audio(soundData);
-
     const animateOpeningBox = () => {
       // Replace the closed envelope with the open one
       $closed_envelope.removeClass("reveal");
@@ -110,7 +106,7 @@ class Gacha extends Component {
     //   the animations, making the UI "feel" more snappy.
 
     $closed_envelope.off().on("click", () => {
-      audio.play().then(animateOpeningBox);
+      animateOpeningBox();
     });
   }
 
@@ -121,6 +117,16 @@ class Gacha extends Component {
     this.setState({
       envelopeIsOpened: true,
     });
+    this.enableSound().play();
+  }
+
+  // Creates audio object from new sound URL
+
+  enableSound() {
+    const soundElement = document.getElementsByClassName("data")[0];
+    soundElement.setAttribute("data-open-sound-url", "/statics/sound/" + this.state.open_sound);
+    const soundData = soundElement.getAttribute("data-open-sound-url");
+    return new Audio(soundData);
   }
 
   // Retrieves data before presentation of the virtual DOM

--- a/client/components/Gacha/Gacha.jsx
+++ b/client/components/Gacha/Gacha.jsx
@@ -14,7 +14,7 @@ class Gacha extends Component {
       rarity: "",
       envelope_image_closed: "",
       envelope_image_open: "",
-      open_sound: "",
+      open_sound: null,
       envelopeIsOpened: false
     };
 
@@ -22,7 +22,6 @@ class Gacha extends Component {
     this.getGacha = this.getGacha.bind(this);
     this.enableGachaAnimation = this.enableGachaAnimation.bind(this);
     this.openEnvelope = this.openEnvelope.bind(this);
-    this.enableSound = this.enableSound.bind(this);
   }
 
   // Resets game state to default states; open_sound has to be pre-populated
@@ -36,7 +35,7 @@ class Gacha extends Component {
       rarity: "",
       envelope_image_closed: "loading.gif",
       envelope_image_open: "",
-      open_sound: "r_open.mp3",
+      open_sound: null,
       envelopeIsOpened: false
     });
   }
@@ -72,7 +71,7 @@ class Gacha extends Component {
         rarity: received.data.rarity,
         envelope_image_closed: received.data.envelope_image_closed,
         envelope_image_open: received.data.envelope_image_open,
-        open_sound: received.data.open_sound
+        open_sound: new Audio("/statics/sound/" + received.data.open_sound)
       });
     });
   }
@@ -105,9 +104,9 @@ class Gacha extends Component {
     //   Putting the animation crap in here ensures the audio begins to play before
     //   the animations, making the UI "feel" more snappy.
 
-    $closed_envelope.off().on("click", () => {
-      animateOpeningBox();
-    });
+    // $closed_envelope.off().on("click", () => {
+    //   animateOpeningBox();
+    // });
   }
 
   // Triggers envelopeIsOpened state upon clicking a closed envelope
@@ -117,16 +116,7 @@ class Gacha extends Component {
     this.setState({
       envelopeIsOpened: true,
     });
-    this.enableSound().play();
-  }
-
-  // Creates audio object from new sound URL
-
-  enableSound() {
-    const soundElement = document.getElementsByClassName("data")[0];
-    soundElement.setAttribute("data-open-sound-url", "/statics/sound/" + this.state.open_sound);
-    const soundData = soundElement.getAttribute("data-open-sound-url");
-    return new Audio(soundData);
+    this.state.open_sound.play();
   }
 
   // Retrieves data before presentation of the virtual DOM

--- a/client/components/Gacha/GachaContent.jsx
+++ b/client/components/Gacha/GachaContent.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 
 import GachaButtons from './GachaButtons.jsx';
 
@@ -9,16 +10,24 @@ const GachaContent = ({ gameState, getGacha, openEnvelope }) => {
   if (gameState.envelopeIsOpened) {
     envelopeClosedClasses.push('hide');
     envelopeOpenedClasses.push('reveal');
+    console.log('transitioning to opened');
+    console.log('what is envelopeOpened now:', envelopeOpenedClasses.join(' '));
+    console.log('what is envelopeClosed now:', envelopeClosedClasses.join(' '));
   } else {
     envelopeClosedClasses.push('reveal');
     envelopeOpenedClasses.push('hide');
+    console.log('transitioning to closed');
+    console.log('what is envelopeOpened now:', envelopeOpenedClasses.join(' '));
+    console.log('what is envelopeClosed now:', envelopeClosedClasses.join(' '));
   }
 
   return (
     <div className="gacha-container">
       <div className="envelope-image-container">
-        <img className="envelope-image envelope-closed reveal" onClick={openEnvelope} src={"/statics/i/" + gameState.envelope_image_closed} />
-        <img className="envelope-image envelope-open hide" src={"/statics/i/" + gameState.envelope_image_open} />
+        <ReactCSSTransitionGroup transitionEnterTimeOut={3000}>
+          <img className={envelopeClosedClasses.join(' ')} onClick={openEnvelope} src={"/statics/i/" + gameState.envelope_image_closed} />
+          <img className={envelopeOpenedClasses.join(' ')} src={"/statics/i/" + gameState.envelope_image_open} />
+        </ReactCSSTransitionGroup>
       </div>
       <div className="opened-card-container hide">
         <span className="aidoru-name">
@@ -27,7 +36,6 @@ const GachaContent = ({ gameState, getGacha, openEnvelope }) => {
         <img className="aidoru-image" src={gameState.card_image_url}/>
         <GachaButtons getGacha={getGacha} />
       </div>
-      <div className="data" data-open-sound-url={"/statics/sound/" + gameState.open_sound}></div>
     </div>
   );
 };

--- a/client/components/Gacha/GachaContent.jsx
+++ b/client/components/Gacha/GachaContent.jsx
@@ -2,11 +2,22 @@ import React from 'react';
 
 import GachaButtons from './GachaButtons.jsx';
 
-const GachaContent = ({ gameState, getGacha }) => {
+const GachaContent = ({ gameState, getGacha, openEnvelope }) => {
+  const envelopeClosedClasses = ['envelope-image envelope-closed'];
+  const envelopeOpenedClasses = ['envelope-image envelope-open'];
+
+  if (gameState.envelopeIsOpened) {
+    envelopeClosedClasses.push('hide');
+    envelopeOpenedClasses.push('reveal');
+  } else {
+    envelopeClosedClasses.push('reveal');
+    envelopeOpenedClasses.push('hide');
+  }
+
   return (
     <div className="gacha-container">
       <div className="envelope-image-container">
-        <img className="envelope-image envelope-closed" src={"/statics/i/" + gameState.envelope_image_closed} />
+        <img className="envelope-image envelope-closed reveal" onClick={openEnvelope} src={"/statics/i/" + gameState.envelope_image_closed} />
         <img className="envelope-image envelope-open hide" src={"/statics/i/" + gameState.envelope_image_open} />
       </div>
       <div className="opened-card-container hide">

--- a/client/components/Gacha/GachaContent.jsx
+++ b/client/components/Gacha/GachaContent.jsx
@@ -4,29 +4,37 @@ import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import GachaButtons from './GachaButtons.jsx';
 
 const GachaContent = ({ gameState, getGacha, openEnvelope }) => {
-  const envelopeClosedClasses = ['envelope-image envelope-closed'];
-  const envelopeOpenedClasses = ['envelope-image envelope-open'];
-
-  if (gameState.envelopeIsOpened) {
-    envelopeClosedClasses.push('hide');
-    envelopeOpenedClasses.push('reveal');
-    console.log('transitioning to opened');
-    console.log('what is envelopeOpened now:', envelopeOpenedClasses.join(' '));
-    console.log('what is envelopeClosed now:', envelopeClosedClasses.join(' '));
-  } else {
-    envelopeClosedClasses.push('reveal');
-    envelopeOpenedClasses.push('hide');
-    console.log('transitioning to closed');
-    console.log('what is envelopeOpened now:', envelopeOpenedClasses.join(' '));
-    console.log('what is envelopeClosed now:', envelopeClosedClasses.join(' '));
-  }
+  // const envelopeClosedClasses = ['envelope-image envelope-closed'];
+  // const envelopeOpenedClasses = ['envelope-image envelope-open'];
+  //
+  // if (gameState.envelopeIsOpened) {
+  //   envelopeClosedClasses.push('hide');
+  //   envelopeOpenedClasses.push('reveal');
+  //   console.log('transitioning to opened');
+  //   console.log('what is envelopeOpened now:', envelopeOpenedClasses.join(' '));
+  //   console.log('what is envelopeClosed now:', envelopeClosedClasses.join(' '));
+  // } else {
+  //   envelopeClosedClasses.push('reveal');
+  //   envelopeOpenedClasses.push('hide');
+  //   console.log('transitioning to closed');
+  //   console.log('what is envelopeOpened now:', envelopeOpenedClasses.join(' '));
+  //   console.log('what is envelopeClosed now:', envelopeClosedClasses.join(' '));
+  // }
 
   return (
     <div className="gacha-container">
       <div className="envelope-image-container">
-        <ReactCSSTransitionGroup transitionEnterTimeOut={3000}>
-          <img className={envelopeClosedClasses.join(' ')} onClick={openEnvelope} src={"/statics/i/" + gameState.envelope_image_closed} />
-          <img className={envelopeOpenedClasses.join(' ')} src={"/statics/i/" + gameState.envelope_image_open} />
+        <ReactCSSTransitionGroup
+          transitionName="reveal"
+          transitionEnterTimeout={450}
+          transitionLeave={false}
+          transitionAppear={true}
+          transitionAppearTimeout={450}>
+          {
+            gameState.envelopeIsOpened ?
+            <img key={1} className="envelope open" src={"/statics/i/" + gameState.envelope_image_open} /> :
+            <img key={1} className="envelope closed" onClick={openEnvelope} src={"/statics/i/" + gameState.envelope_image_closed} />
+          }
         </ReactCSSTransitionGroup>
       </div>
       <div className="opened-card-container hide">

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "mysql2": "^1.4.2",
     "path": "^0.12.7",
     "react": "^15.6.1",
+    "react-addons-css-transition-group": "^15.6.2",
     "react-bootstrap": "^0.31.5",
     "react-dom": "^15.6.1",
     "react-markdown": "^2.5.0",

--- a/public/css/sif.css
+++ b/public/css/sif.css
@@ -8,38 +8,36 @@
   max-width: 1024px;
 }
 
-.envelope-image {
+.envelope {
   -ms-transform: rotate(7deg); /* IE 9 */
   -webkit-transform: rotate(7deg); /* Chrome, Safari, Opera */
   transform: rotate(7deg);
   max-width: 50%;
+  /*transition: transform 450ms;*/
 }
 
-.envelope-image.envelope-closed.reveal {
-  opacity: 1;
-  visibility: visible;
+/*.envelope:hover {*/
+  /*transform: rotate(7deg) scale(1.1, 1.1);*/
+/*}*/
+
+.reveal-enter {
+  transform: rotate(7deg) scale(1, 1);
 }
 
-.envelope-image.envelope-closed.hide {
+.reveal-enter-active {
+  transform: rotate(7deg) scale(1.1, 1.1);
+  -webkit-transition: all 450ms;
+  transition: all 450ms ease-out;
+}
+
+.reveal-appear {
   opacity: 0;
-  visibility: hidden;
-  height: 0;
-  width: 0;
 }
 
-.envelope-image.envelope-open.reveal {
-  width: 300px;
+.reveal-appear-active {
   opacity: 1;
-  visibility: visible;
-  -webkit-transition: width 3s, height 0ms 450ms, opacity 0ms 450ms;
-  transition: width 3s ease-in-out, height 0ms 450ms, opacity 0ms 450ms;
-}
-
-.envelope-image.envelope-open.hide {
-  opacity: 0;
-  visibility: hidden;
-  -webkit-transition: width 3s 0ms;
-  transition: width 3s ease-in-out 0ms;
+  -webkit-transition: opacity 500ms;
+  transition: opacity 500ms;
 }
 
 .aidoru-name a {

--- a/public/css/sif.css
+++ b/public/css/sif.css
@@ -16,10 +16,6 @@
 }
 
 .envelope-image.envelope-closed.reveal {
-  -ms-transform: rotate(7deg); /* IE 9 */
-  -webkit-transform: rotate(7deg); /* Chrome, Safari, Opera */
-  transform: rotate(7deg);
-  max-width: 50%;
   opacity: 1;
   visibility: visible;
 }
@@ -27,6 +23,23 @@
 .envelope-image.envelope-closed.hide {
   opacity: 0;
   visibility: hidden;
+  height: 0;
+  width: 0;
+}
+
+.envelope-image.envelope-open.reveal {
+  width: 300px;
+  opacity: 1;
+  visibility: visible;
+  -webkit-transition: width 3s, height 0ms 450ms, opacity 0ms 450ms;
+  transition: width 3s ease-in-out, height 0ms 450ms, opacity 0ms 450ms;
+}
+
+.envelope-image.envelope-open.hide {
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transition: width 3s 0ms;
+  transition: width 3s ease-in-out 0ms;
 }
 
 .aidoru-name a {

--- a/public/css/sif.css
+++ b/public/css/sif.css
@@ -13,7 +13,20 @@
   -webkit-transform: rotate(7deg); /* Chrome, Safari, Opera */
   transform: rotate(7deg);
   max-width: 50%;
+}
 
+.envelope-image.envelope-closed.reveal {
+  -ms-transform: rotate(7deg); /* IE 9 */
+  -webkit-transform: rotate(7deg); /* Chrome, Safari, Opera */
+  transform: rotate(7deg);
+  max-width: 50%;
+  opacity: 1;
+  visibility: visible;
+}
+
+.envelope-image.envelope-closed.hide {
+  opacity: 0;
+  visibility: hidden;
 }
 
 .aidoru-name a {


### PR DESCRIPTION
I've already decoupled the Gacha sound activation from React so now it works without jQuery.  As of right now, I'm trying to get CSS Transitions to work with React using ReactCSSTransitionGroups and new CSS rules containing the transition property, but so far no luck.  The underlying problem seems to be that the mounting/un-mounting/updating of the component and states are cutting out the transitions, which `ReactCSSTransitionGroup` is supposed to help prevent, but I can't seem to get it to work.