### PR TITLE
Enhance feature to correctly share idolized card when flipped

### DIFF
--- a/client/components/Gacha/GachaAppContainer.jsx
+++ b/client/components/Gacha/GachaAppContainer.jsx
@@ -42,7 +42,7 @@ class GachaAppContainer extends PureComponent {
 
   handleShareWaifu() {
     if (this.props.card.id) {
-      this.props.dispatch(shareCard(this.props.card.id));
+      this.props.dispatch(shareCard(this.props.card.id, this.state.idolized));
     }
   }
 

--- a/client/components/Gacha/GachaContent.jsx
+++ b/client/components/Gacha/GachaContent.jsx
@@ -28,13 +28,13 @@ const GachaContent = (props) => {
     <div className="gacha-container">
       {animationPhase !== 'open_finished'
         ? (
-          <div onClick={handleEnvelopeOpen} className="envelope-image-container">
+          <div className="envelope-image-container">
             <CSSTransition
               in={animationPhase === 'opening'}
               classNames="envelope"
               timeout={{ enter: 450, exit: 300 }}>
 
-              <img className="envelope-image" src={imageUrl} />
+              <img onClick={handleEnvelopeOpen} className="envelope-image" src={imageUrl} />
             </CSSTransition>
           </div>
         )

--- a/client/modules/gacha.js
+++ b/client/modules/gacha.js
@@ -38,14 +38,14 @@ const CARD_OPENED = 'gacha/CARD_OPENED';
 
 
 // ACTION CREATORS
-export function shareCard(card_id) {
+export function shareCard(card_id, idolized = false) {
   return (dispatch, getState) => {
     dispatch({
       type: SHARE_STARTED,
     });
 
     const axios = require('axios'); // FIXME (derek) refactor with the Api Client
-    return axios.post("/api/sif/share", { card_id })
+    return axios.post("/api/sif/share", { card_id, idolized })
       .then(received => {
         dispatch({
           type: SHARE_SUCCESS,

--- a/lib/Slack/Slackbot.js
+++ b/lib/Slack/Slackbot.js
@@ -61,6 +61,10 @@ class Slackbot {
    * Resolves into a result object containing information about the message that was sent (including timestamp etc).
    */
   sendMessage(message_text, channel_id) {
+    if (!this.is_connected) {
+      return Promise.reject(new Error('Cannot use Slackbot to send messages as slackbot is not connected'));
+    }
+
     return this.rtm.sendMessage(message_text, channel_id);
   }
 
@@ -68,6 +72,9 @@ class Slackbot {
    * Callback function
    */
   receiveMessage(slack_message) {
+    if (!this.is_connected) {
+      throw new Error('Cannot use Slackbot to send messages as slackbot is not connected');
+    }
     const message = new Message(slack_message);
 
     if (message.isEditMessage()) {

--- a/server/controllers/SifApiController.js
+++ b/server/controllers/SifApiController.js
@@ -15,6 +15,7 @@ class SifApiController extends Controller {
 
   share_roll_action(req, res, next) {
     const card_id = req.body.card_id;
+    const idolized = !!req.body.idolized;
 
     if (!card_id) {
       return res.status(400).send({
@@ -47,7 +48,9 @@ class SifApiController extends Controller {
         return Promise.resolve(getPersonString)
           .then(person => {
             const sif_channel_id = require('../../lib/Slack/SlackChannels').schoolidolfestival;
-            const card_string = '[' + card.getId() + '] ' + card.getName() + ' - ' + card.getImageUrl();
+            const card_string = '[' + card.getId() + '] '
+              + card.getName() + ' - '
+              + (idolized ? card.getIdolizedImageUrl() : card.getImageUrl());
 
             const text = `Look! ${person} rolled a ${card_string}`;
             return this.get('chuubot').sendMessage(text, sif_channel_id)


### PR DESCRIPTION
Originally the slack share feature only shares the unidolized version. 

Also better error message when sharing waifu when slackbot not connected.