### PR TITLE
[fix] moved creation of htmlaudioelement to loading phase of the game

### DIFF
--- a/client/components/Gacha/GachaAppContainer.jsx
+++ b/client/components/Gacha/GachaAppContainer.jsx
@@ -47,13 +47,7 @@ class GachaAppContainer extends PureComponent {
   }
 
   handleEnvelopeOpen() {
-    if (this.state.animationPhase === 'closed') {
-      const audio = new Audio('/statics/sound/' + this.props.card.open_sound);
-
-      // Play kinky music
-      //   Putting the animation crap in here ensures the audio begins to play before
-      //   the animations, making the UI "feel" more snappy.
-      return audio.play()
+      return this.state.animationPhase === 'closed'? this.props.card.open_sound.play()
         .then(() => {
           this.setState({
             animationPhase: 'opening',
@@ -63,8 +57,7 @@ class GachaAppContainer extends PureComponent {
           // speed in the GachaContent component, but in the future we should use
           // the transition group events to fire this as a callback.
           setTimeout((() => this.setState({ animationPhase: 'open_finished' })), 450);
-        });
-    }
+        }) : false;
   }
 
   handleIdolCardClick() {

--- a/client/modules/gacha.js
+++ b/client/modules/gacha.js
@@ -116,7 +116,8 @@ export default function reducer(state = {}, action) {
           rarity: card.rarity,
           envelope_image_closed: card.envelope_image_closed,
           envelope_image_open: card.envelope_image_open,
-          open_sound: card.open_sound
+          open_sound: new Audio('/statics/sound/' + card.open_sound),
+
         },
       });
       newState.loading = false;


### PR DESCRIPTION
Not sure if this fix will do anything to be honest, it's also a small fix.  I logically moved the creation of the htmlaudioelement blob into the action creator where it retrieves the gacha metadata from schoolido.lu.  The reason I did that is because that is during the loading phase of the game and it turns out the creation of the htmlaudioelement blob is indeed asynchonrous according to MDN, so to me it made more sense to be there so it is guaranteed(?) to be ready by the time the user triggers a click on the envelope.