### PR TITLE
[feature] Popover for Card Statistics in Gacha Game

### DIFF
--- a/client/components/Gacha/GachaAppContainer.jsx
+++ b/client/components/Gacha/GachaAppContainer.jsx
@@ -16,9 +16,9 @@ class GachaAppContainer extends PureComponent {
       idolized: false,
     };
 
+    this.handleRerollGacha = this.handleRerollGacha.bind(this);
     this.handleShareWaifu = this.handleShareWaifu.bind(this);
     this.handleEnvelopeOpen = this.handleEnvelopeOpen.bind(this);
-    this.handleRerollGacha = this.handleRerollGacha.bind(this);
     this.handleIdolCardClick = this.handleIdolCardClick.bind(this);
   }
 

--- a/client/components/Gacha/GachaButtons.jsx
+++ b/client/components/Gacha/GachaButtons.jsx
@@ -1,13 +1,45 @@
 import React from 'react';
-import { Button } from 'react-bootstrap';
+import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 
-const GachaButtons = ({ handleRerollGacha, handleShareWaifu }) => {
+const GachaButtons = ({ handleRerollGacha, handleShareWaifu, card_stats }) => {
+
+  const stats = card_stats ? card_stats : {
+    name: "",
+    attribute: "",
+    skill: "",
+    skill_details: "",
+    center_skill: "",
+    center_skill_details: "",
+    non_idolized_maximum_statistics_smile: "",
+    idolized_maximum_statistics_smile: "",
+    non_idolized_maximum_statistics_pure: "",
+    idolized_maximum_statistics_pure: "",
+    non_idolized_maximum_statistics_cool: "",
+    idolized_maximum_statistics_cool: "",
+  };
+
+  const gachaInfoOverlay = (
+    <Popover id="popover-trigger-click" title="Card Statistics">
+      <strong>Name:</strong> {stats.name} <br/>
+      <strong>Attribute:</strong> {stats.attribute} <br/>
+      <strong>Skill: [{stats.skill}]</strong> {stats.skill_details} <br/>
+      <strong>Center Skill: [{stats.center_skill}]</strong> {stats.center_skill_details} <br/>
+      <strong>Max Smile Points:</strong> {stats.non_idolized_maximum_statistics_smile} ~ {stats.idolized_maximum_statistics_smile} <br/>
+      <strong>Max Pure Points:</strong> {stats.non_idolized_maximum_statistics_pure} ~ {stats.idolized_maximum_statistics_pure} <br/>
+      <strong>Max Cool Points:</strong> {stats.non_idolized_maximum_statistics_cool} ~ {stats.idolized_maximum_statistics_cool} <br/>
+    </Popover>
+  );
+
   return (
     <div className="aidoru-buttons">
       <Button className="gacha-button" onClick={handleRerollGacha}>Re-roll</Button>
+      <OverlayTrigger trigger="click" placement="top" overlay={gachaInfoOverlay}>
+        <Button className="gacha-button">Stats</Button>
+      </OverlayTrigger>
       <Button className="gacha-button" onClick={handleShareWaifu}>Share this waifu</Button>
     </div>
   );
 };
+
 
 export default GachaButtons;

--- a/client/components/Gacha/GachaButtons.jsx
+++ b/client/components/Gacha/GachaButtons.jsx
@@ -1,32 +1,32 @@
 import React from 'react';
 import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 
-const GachaButtons = ({ handleRerollGacha, handleShareWaifu, card_stats }) => {
+const stateDefault = {
+  name: "",
+  attribute: "",
+  skill: "",
+  skill_details: "",
+  center_skill: "",
+  center_skill_details: "",
+  non_idolized_maximum_statistics_smile: "",
+  idolized_maximum_statistics_smile: "",
+  non_idolized_maximum_statistics_pure: "",
+  idolized_maximum_statistics_pure: "",
+  non_idolized_maximum_statistics_cool: "",
+  idolized_maximum_statistics_cool: "",
+};
 
-  const stats = card_stats ? card_stats : {
-    name: "",
-    attribute: "",
-    skill: "",
-    skill_details: "",
-    center_skill: "",
-    center_skill_details: "",
-    non_idolized_maximum_statistics_smile: "",
-    idolized_maximum_statistics_smile: "",
-    non_idolized_maximum_statistics_pure: "",
-    idolized_maximum_statistics_pure: "",
-    non_idolized_maximum_statistics_cool: "",
-    idolized_maximum_statistics_cool: "",
-  };
+const GachaButtons = ({ handleRerollGacha, handleShareWaifu, card_stats = stateDefault }) => {
 
   const gachaInfoOverlay = (
     <Popover id="popover-trigger-click" title="Card Statistics">
-      <strong>Name:</strong> {stats.name} <br/>
-      <strong>Attribute:</strong> {stats.attribute} <br/>
-      <strong>Skill: [{stats.skill}]</strong> {stats.skill_details} <br/>
-      <strong>Center Skill: [{stats.center_skill}]</strong> {stats.center_skill_details} <br/>
-      <strong>Max Smile Points:</strong> {stats.non_idolized_maximum_statistics_smile} ~ {stats.idolized_maximum_statistics_smile} <br/>
-      <strong>Max Pure Points:</strong> {stats.non_idolized_maximum_statistics_pure} ~ {stats.idolized_maximum_statistics_pure} <br/>
-      <strong>Max Cool Points:</strong> {stats.non_idolized_maximum_statistics_cool} ~ {stats.idolized_maximum_statistics_cool} <br/>
+      <strong>Name:</strong> {card_stats.name} <br/>
+      <strong>Attribute:</strong> {card_stats.attribute} <br/>
+      <strong>Skill: [{card_stats.skill}]</strong> {card_stats.skill_details} <br/>
+      <strong>Center Skill: [{card_stats.center_skill}]</strong> {card_stats.center_skill_details} <br/>
+      <strong>Max Smile Points:</strong> {card_stats.non_idolized_maximum_statistics_smile} ~ {card_stats.idolized_maximum_statistics_smile} <br/>
+      <strong>Max Pure Points:</strong> {card_stats.non_idolized_maximum_statistics_pure} ~ {card_stats.idolized_maximum_statistics_pure} <br/>
+      <strong>Max Cool Points:</strong> {card_stats.non_idolized_maximum_statistics_cool} ~ {card_stats.idolized_maximum_statistics_cool} <br/>
     </Popover>
   );
 

--- a/client/components/Gacha/GachaContent.jsx
+++ b/client/components/Gacha/GachaContent.jsx
@@ -16,6 +16,7 @@ const GachaContent = (props) => {
   const buttonProps = {
     handleRerollGacha,
     handleShareWaifu,
+    card_stats: card.card_stats,
   };
 
   const imageUrl = animationPhase === 'opening'

--- a/client/modules/gacha.js
+++ b/client/modules/gacha.js
@@ -117,7 +117,7 @@ export default function reducer(state = {}, action) {
           envelope_image_closed: card.envelope_image_closed,
           envelope_image_open: card.envelope_image_open,
           open_sound: new Audio('/statics/sound/' + card.open_sound),
-
+          card_stats: card.card_stats,
         },
       });
       newState.loading = false;

--- a/lib/SchoolIdo.lu/Card.js
+++ b/lib/SchoolIdo.lu/Card.js
@@ -15,6 +15,18 @@ class Card {
     this.translated_collection = this.card_data['translated_collection'];
     this.main_unit = this.card_data['idol']['main_unit'];
     this.sub_unit = this.card_data['idol']['sub_unit'];
+
+    this.attribute = this.card_data['attribute'];
+    this.skill = this.card_data['skill'];
+    this.skill_details = this.card_data['skill_details'];
+    this.center_skill = this.card_data['center_skill'];
+    this.center_skill_details = this.card_data['center_skill_details'];
+    this.non_idolized_maximum_statistics_smile = this.card_data['non_idolized_maximum_statistics_smile'];
+    this.non_idolized_maximum_statistics_pure = this.card_data['non_idolized_maximum_statistics_pure'];
+    this.non_idolized_maximum_statistics_cool = this.card_data['non_idolized_maximum_statistics_cool'];
+    this.idolized_maximum_statistics_smile = this.card_data['idolized_maximum_statistics_smile'];
+    this.idolized_maximum_statistics_pure = this.card_data['idolized_maximum_statistics_pure'];
+    this.idolized_maximum_statistics_cool = this.card_data['idolized_maximum_statistics_cool'];
   }
 
   getId() {
@@ -65,6 +77,26 @@ class Card {
    */
   getSubUnit() {
     return this.sub_unit;
+  }
+
+  /**
+   * Returns card statistical data for UI overlay
+   */
+  getCardStats() {
+    return {
+      name: this.name,
+      attribute: this.attribute,
+      skill: this.skill,
+      skill_details: this.skill_details,
+      center_skill: this.center_skill,
+      center_skill_details: this.center_skill_details,
+      non_idolized_maximum_statistics_smile: this.non_idolized_maximum_statistics_smile,
+      non_idolized_maximum_statistics_pure: this.non_idolized_maximum_statistics_pure,
+      non_idolized_maximum_statistics_cool: this.non_idolized_maximum_statistics_cool,
+      idolized_maximum_statistics_smile: this.idolized_maximum_statistics_smile,
+      idolized_maximum_statistics_pure: this.idolized_maximum_statistics_pure,
+      idolized_maximum_statistics_cool: this.idolized_maximum_statistics_cool,
+    };
   }
 }
 

--- a/server/controllers/SifApiController.js
+++ b/server/controllers/SifApiController.js
@@ -89,6 +89,7 @@ class SifApiController extends Controller {
       envelope_image_closed: envelope_image_closed,
       envelope_image_open: envelope_image_open,
       open_sound: open_sound,
+      card_stats: card.getCardStats(),
     };
     res.send(data);
   }


### PR DESCRIPTION
__[4/16-4/17/2018]__
__Changes Made:__
1) Added new method to School Idol library class to retrieve extra card statistics for popover
2) Added new property to idol JSON (`card_stats`) to store the extra card statistics
3) Added new button to `GachaButton` component to include overlay trigger and the popover

__Possible Impact:__
I ran into an issue while coding where the app would hard crash if there was nothing retrieved from the `card_stats` property yet due to the `GachaButton` component already rendering when top-level `GachaAppContainer` is loaded.  This was remedied by setting a default state for the properties in `card_stats` so it would temporarily be empty before the data is asynchronously included and the `GachaButton` component is then re-rendered to have the correct card statistics.  **Otherwise, this new feature should not have any impact affecting other code in the game.**

__Rollback:__
Revert to previous working commit.

__Reference:__
N/A