### PR TITLE
[pkg-upgrade] @slack/client

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "Derek Wang",
   "homepage": "https://chuuni.me",
   "dependencies": {
-    "@slack/client": "^3.12.0",
+    "@slack/client": "^4.2.2",
     "axios": "^0.16.2",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",


### PR DESCRIPTION
As per Github's recommendation, @slack/client package was revised to a newer version to try and patch a security vulnerability.