### PR TITLE
[npm-update] hoek@2.16.3 --> 4.2.1 vulnerability fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,8 +69,7 @@
     "service-container": "github:ryxias/service-container#v1.0.3",
     "showdown": "^1.7.4",
     "uuid": "^3.2.1",
-    "webpack": "^3.5.5",
-    "webpack-dev-server": "^2.7.1"
+    "webpack": "^4.8.3"
   },
   "devDependencies": {
     "axios-mock-adapter": "^1.15.0",


### PR DESCRIPTION
Removing webpack-dev-server as it has not been used; updated webpack (3.11.0 --> 4.8.3), which uses hoek@4.2.1.